### PR TITLE
chore: run development workflow on push to main

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "patch": {
     "automerge": true
   },

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -1,6 +1,8 @@
 name: Development
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -2,9 +2,9 @@ name: Development
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -23,4 +23,3 @@ jobs:
 
       - name: Build code
         run: yarn build
-

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install
+        run: yarn install --frozen-lockfile
+
       - name: Check formatting
         run: yarn test:format
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ steps:
 Inputs available through `with`:
 
 | Input  | Description                                                                      | Required |
-|--------|----------------------------------------------------------------------------------| ------- |
-| from   | Commit SHA, tag or reference as starting point                                   | ✔       |
-| to     | Commit SHA, tag or reference as ending point                                     | ✔       |
-| labels | Labels that should be added to issues/PRs. Non-existing labels will be created   | ✔       |
-| color  | Color for newly created labels. If not specified GitHub will pick a random color |         |
+| ------ | -------------------------------------------------------------------------------- | -------- |
+| from   | Commit SHA, tag or reference as starting point                                   | ✔        |
+| to     | Commit SHA, tag or reference as ending point                                     | ✔        |
+| labels | Labels that should be added to issues/PRs. Non-existing labels will be created   | ✔        |
+| color  | Color for newly created labels. If not specified GitHub will pick a random color |          |
 
 ### Complete workflow
 


### PR DESCRIPTION
The development workflow will now be run on pushes to the main branch