### PR TITLE
chore: push build commits with own email

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,4 +19,6 @@ jobs:
       - name: Commit and push changes
         uses: actions-js/push@v1.3
         with:
+          author_email: 20122620+dlavrenuek@users.noreply.github.com
+          author_name: Dimitri Lavrenük
           github_token: ${{ secrets.BUILD_PUSH_TOKEN }}


### PR DESCRIPTION
Build commits are now performed in the name of my account instead of github-actions